### PR TITLE
Rws dev

### DIFF
--- a/src/i2c_driver.h
+++ b/src/i2c_driver.h
@@ -122,6 +122,8 @@ public:
     // Set 'send_stop' to false if are going to make another transfer.
     // Call finished() to see if the call has finished.
     virtual void read_async(uint8_t address, uint8_t* buffer, size_t num_bytes, bool send_stop) = 0;
+	
+	virtual void reset(void);
 };
 
 class I2CSlave : public I2CDriver {

--- a/src/i2c_driver_wire.cpp
+++ b/src/i2c_driver_wire.cpp
@@ -129,7 +129,7 @@ void I2CDriverWire::finish() {
 	
 	// Reset the bus
 	if (reset_on_timeout) {
-//		Serial.println("resetting the bus not supported yet!");
+		reset();
 	}
 }
 

--- a/src/i2c_driver_wire.cpp
+++ b/src/i2c_driver_wire.cpp
@@ -118,13 +118,19 @@ void I2CDriverWire::before_transmit(uint16_t address) {
 }
 
 void I2CDriverWire::finish() {
-    elapsedMillis timeout;
-    while (timeout < timeout_millis) {
+    elapsedMicros timeout;
+    while (timeout < timeout_micros) {
         if (master.finished()) {
             return;
         }
     }
-    Serial.println("Timed out waiting for transfer to finish.");
+	timeout_flag = true;
+//    Serial.println("Timed out waiting for transfer to finish.");
+	
+	// Reset the bus
+	if (reset_on_timeout) {
+//		Serial.println("resetting the bus not supported yet!");
+	}
 }
 
 void I2CDriverWire::on_receive_wrapper(size_t num_bytes, uint16_t address) {

--- a/src/i2c_driver_wire.h
+++ b/src/i2c_driver_wire.h
@@ -11,6 +11,8 @@
 #include "imx_rt1060/imx_rt1060_i2c_driver.h"
 #endif
 
+#define WIRE_HAS_TIMEOUT
+
 // An implementation of the Wire library as defined at
 //   https://www.arduino.cc/en/reference/wire
 // This header also defines TwoWire as an alias for I2CDriverWire
@@ -24,7 +26,11 @@ public:
     static const size_t tx_buffer_length = 32;
 
     // Time to wait for a read or write to complete in millis
-    static const uint32_t timeout_millis = 200;
+    static const uint32_t	default_timeout_micros = 200000;
+	static const bool		default_reset_on_timeout = false;
+	uint32_t	timeout_micros = default_timeout_micros;
+	bool		reset_on_timeout = default_reset_on_timeout;
+	bool		timeout_flag = false;
 
     // Indicates that there is no more data to read.
     static const int no_more_bytes = -1;
@@ -91,6 +97,18 @@ public:
     int read() override;
 
     int peek() override;
+
+	void Wire.setWireTimeout(uint32_t timeout, bool reset_on_timout) {
+								timeout_micros = timeout;
+								reset_on_timeout = reset_on_timout;
+								if (reset_on_timeout) {
+									//		Serial.println("resetting the bus not supported yet!");
+								};};
+
+	void Wire.setWireTimeout(void) {timeout_micros = default_timeout_micros; 
+								reset_on_timeout = default_reset_on_timeout;);
+	bool getWireTimeoutFlag(void) {return timeout_flag;);
+	void clearWireTimeoutFlag(void) {timeout_flag = false;};
 
     // Registers a function to be called when a slave device receives
     // a transmission from a master.

--- a/src/i2c_driver_wire.h
+++ b/src/i2c_driver_wire.h
@@ -98,18 +98,18 @@ public:
 
     int peek() override;
 
-	void Wire.setWireTimeout(uint32_t timeout, bool reset_on_timout) {
+	void setWireTimeout(uint32_t timeout, bool reset_on_timout) {
 								timeout_micros = timeout;
 								reset_on_timeout = reset_on_timout;
-								if (reset_on_timeout) {
-									//		Serial.println("resetting the bus not supported yet!");
-								};};
+								};
 
-	void Wire.setWireTimeout(void) {timeout_micros = default_timeout_micros; 
-								reset_on_timeout = default_reset_on_timeout;);
-	bool getWireTimeoutFlag(void) {return timeout_flag;);
+	void setWireTimeout(void) {timeout_micros = default_timeout_micros; 
+								reset_on_timeout = default_reset_on_timeout;};
+	bool getWireTimeoutFlag(void) {return timeout_flag;};
 	void clearWireTimeoutFlag(void) {timeout_flag = false;};
 
+	void reset(void) {master.reset();};
+	
     // Registers a function to be called when a slave device receives
     // a transmission from a master.
     //

--- a/src/imx_rt1060/imx_rt1060_i2c_driver.cpp
+++ b/src/imx_rt1060/imx_rt1060_i2c_driver.cpp
@@ -445,6 +445,20 @@ inline void IMX_RT1060_I2CMaster::clear_all_msr_flags() {
                   LPI2C_MSR_EPF | LPI2C_MSR_RDF | LPI2C_MSR_TDF);
 }
 
+
+void IMX_RT1060_I2CMaster::reset() {
+	stop(port,config.irq);
+	// Now do 9 simulated clock cycles (@ 100Khz) to clear everything out
+	for (int i=0; i<9; i++) {
+		digitalWrite(config.scl_pin, 0);
+		delayMicroseconds(5);
+		digitalWrite(config.sc_pin,1);
+		delayMicroseconds(5);
+	}
+	begin(saveFrequency);
+}
+
+
 bool IMX_RT1060_I2CMaster::start(uint8_t address, uint32_t direction) {
     if (!finished()) {
         // We haven't completed the previous transaction yet
@@ -528,6 +542,7 @@ void IMX_RT1060_I2CMaster::abort_transaction_async() {
 // Supports 100 kHz, 400 kHz and 1 MHz modes.
 void IMX_RT1060_I2CMaster::set_clock(uint32_t frequency) {
     I2CMasterConfiguration timings;
+	savedFrequency = frequency;
     if (frequency < 400'000) {
         // Use Standard Mode - up to 100 kHz
         timings = DefaultStandardModeMasterConfiguration;

--- a/src/imx_rt1060/imx_rt1060_i2c_driver.h
+++ b/src/imx_rt1060/imx_rt1060_i2c_driver.h
@@ -124,6 +124,8 @@ public:
 
     void read_async(uint8_t address, uint8_t* buffer, size_t num_bytes, bool send_stop) override;
 
+	void reset(void);		// Does a 9 cycle reset to unblock a stuck i2cLine
+
     // DO NOT call this method directly.
     void _interrupt_service_routine();
 
@@ -155,6 +157,7 @@ private:
     uint8_t tx_fifo_count();
     uint8_t rx_fifo_count();
     void clear_all_msr_flags();
+	uint32_t	savedFrequency;
 };
 
 extern IMX_RT1060_I2CMaster Master;     // Pins 19 and 18; SCL0 and SDA0

--- a/src/imx_rt1060/imx_rt1060_i2c_driver.h
+++ b/src/imx_rt1060/imx_rt1060_i2c_driver.h
@@ -129,6 +129,8 @@ public:
     // DO NOT call this method directly.
     void _interrupt_service_routine();
 
+    IMXRT_LPI2C_Registers* const port;
+
 private:
     enum class State {
         // Busy states
@@ -143,7 +145,7 @@ private:
         stopped             // Transaction has finished. STOP sent.
     };
 
-    IMXRT_LPI2C_Registers* const port;
+//    IMXRT_LPI2C_Registers* const port;
     IMX_RT1060_I2CBase::Config& config;
     I2CBuffer buff;
     volatile State state = State::idle;


### PR DESCRIPTION
Hi Richard,
This update implements a few key items:
1)Creates a variable timeout in the Wire library, along with the associated Reset capability
2) Implements the reset in the IMX code to bitbang the clock until both sda and scl go high again
3) Changes the CLKLO value for the default  master from 37 to 42 which works great for the AIF device.  I was not sure how best to implement this and whether it makes sense to make it global, and if not how to override effectively in a specific implementation.
4) Fixed bug where address NAK was reported as DATA NAK.  This bug fix is not perfect (basically looks if there are still items in the TX queue). but probably good?